### PR TITLE
Add support for ffmpeg_image_transport to Image/Camera displays and point_cloud_transport to PointCloud2 display

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,8 @@
+include:
+  - remote: 'https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/main/.gitlab-ci/docker-ros.yml'
+
+variables:
+  BASE_IMAGE: rwthika/ros2:jazzy
+  COMMAND: rviz2
+  TARGET: dev,run
+  PLATFORM: amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,8 @@ include:
   - remote: 'https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/main/.gitlab-ci/docker-ros.yml'
 
 variables:
-  BASE_IMAGE: rwthika/ros2:jazzy
+  BASE_IMAGE: rwthika/ros2-cuda:jazzy
   COMMAND: rviz2
   TARGET: dev,run
   PLATFORM: amd64
+  RMW_IMPLEMENTATION: rmw_zenoh_cpp

--- a/docker/additional-debs.txt
+++ b/docker/additional-debs.txt
@@ -1,0 +1,2 @@
+ros-${ROS_DISTRO}-ffmpeg-image-transport
+ros-${ROS_DISTRO}-compressed-image-transport

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -110,6 +110,8 @@ public:
 
   ~CameraDisplay() override;
 
+  static std::string getZedCameraInfoTopic(const std::string & base_topic);
+
   // Overrides from Display
   void onInitialize() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -110,8 +110,6 @@ public:
 
   ~CameraDisplay() override;
 
-  static std::string getZedCameraInfoTopic(const std::string & base_topic);
-
   // Overrides from Display
   void onInitialize() override;
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -185,6 +185,28 @@ void CameraDisplay::onInitialize()
   this->addChild(visibility_property_, 0);
 }
 
+std::string CameraDisplay::getZedCameraInfoTopic(const std::string & base_topic)
+{
+  // special case for confidence topic
+  if (base_topic.find("zed/zed_node/confidence/") != std::string::npos) {
+    return "zed/zed_node/rgb/camera_info";
+  }
+  
+  // all other camera topics 
+  size_t zed_pos = base_topic.find("/zed/zed_node/");
+  if (zed_pos != std::string::npos) {
+    size_t pos = zed_pos + 14; // position after "/zed/zed_node/" (14)
+    size_t next_slash = base_topic.find("/", pos);
+    
+    if (next_slash != std::string::npos) {
+      // extract base topic with camera type e.g. "/zed/zed_node/left
+      std::string camera_base = base_topic.substr(0, next_slash);
+      return camera_base + "/camera_info";
+    }
+  }
+
+  return image_transport::getCameraInfoTopic(base_topic);
+}
 
 void CameraDisplay::setupSceneNodes()
 {
@@ -345,8 +367,7 @@ void CameraDisplay::createCameraInfoSubscription()
     // The camera_info topic should be at the same level as the image topic
     // TODO(anyone) Store this in a member variable
 
-    std::string camera_info_topic = image_transport::getCameraInfoTopic(
-      topic_property_->getTopicStd());
+    std::string camera_info_topic = getZedCameraInfoTopic(topic_property_->getTopicStd());
 
     rclcpp::SubscriptionOptions sub_opts;
     sub_opts.event_callbacks.message_lost_callback =
@@ -408,8 +429,7 @@ void CameraDisplay::clear()
   new_caminfo_ = false;
   current_caminfo_.reset();
 
-  std::string camera_info_topic =
-    image_transport::getCameraInfoTopic(topic_property_->getTopicStd());
+  std::string camera_info_topic = getZedCameraInfoTopic(topic_property_->getTopicStd());
 
   setStatus(
     StatusLevel::Warn, CAM_INFO_STATUS,
@@ -455,8 +475,7 @@ bool CameraDisplay::updateCamera()
   }
 
   if (!info) {
-    std::string camera_info_topic = image_transport::getCameraInfoTopic(
-      topic_property_->getTopicStd());
+    std::string camera_info_topic = getZedCameraInfoTopic(topic_property_->getTopicStd());
 
     setStatus(
       StatusLevel::Warn, CAM_INFO_STATUS,

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -67,6 +67,7 @@
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/load_resource.hpp"
 
+#include "rviz_default_plugins/displays/image/get_transport_from_topic.hpp"
 #include "rviz_default_plugins/displays/image/ros_image_texture.hpp"
 
 namespace rviz_default_plugins
@@ -183,29 +184,6 @@ void CameraDisplay::onInitialize()
     rviz_common::loadPixmap("package://rviz_default_plugins/icons/visibility.svg", true));
 
   this->addChild(visibility_property_, 0);
-}
-
-std::string CameraDisplay::getZedCameraInfoTopic(const std::string & base_topic)
-{
-  // special case for confidence topic
-  if (base_topic.find("zed/zed_node/confidence/") != std::string::npos) {
-    return "zed/zed_node/rgb/camera_info";
-  }
-  
-  // all other camera topics 
-  size_t zed_pos = base_topic.find("/zed/zed_node/");
-  if (zed_pos != std::string::npos) {
-    size_t pos = zed_pos + 14; // position after "/zed/zed_node/" (14)
-    size_t next_slash = base_topic.find("/", pos);
-    
-    if (next_slash != std::string::npos) {
-      // extract base topic with camera type e.g. "/zed/zed_node/left
-      std::string camera_base = base_topic.substr(0, next_slash);
-      return camera_base + "/camera_info";
-    }
-  }
-
-  return image_transport::getCameraInfoTopic(base_topic);
 }
 
 void CameraDisplay::setupSceneNodes()
@@ -367,7 +345,8 @@ void CameraDisplay::createCameraInfoSubscription()
     // The camera_info topic should be at the same level as the image topic
     // TODO(anyone) Store this in a member variable
 
-    std::string camera_info_topic = getZedCameraInfoTopic(topic_property_->getTopicStd());
+    std::string camera_info_topic = image_transport::getCameraInfoTopic(
+      getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
     rclcpp::SubscriptionOptions sub_opts;
     sub_opts.event_callbacks.message_lost_callback =
@@ -429,7 +408,8 @@ void CameraDisplay::clear()
   new_caminfo_ = false;
   current_caminfo_.reset();
 
-  std::string camera_info_topic = getZedCameraInfoTopic(topic_property_->getTopicStd());
+  std::string camera_info_topic =
+    image_transport::getCameraInfoTopic(getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
   setStatus(
     StatusLevel::Warn, CAM_INFO_STATUS,
@@ -475,7 +455,8 @@ bool CameraDisplay::updateCamera()
   }
 
   if (!info) {
-    std::string camera_info_topic = getZedCameraInfoTopic(topic_property_->getTopicStd());
+    std::string camera_info_topic = image_transport::getCameraInfoTopic(
+      getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
     setStatus(
       StatusLevel::Warn, CAM_INFO_STATUS,

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
@@ -39,8 +39,10 @@ namespace displays
 bool isRawTransport(const std::string & topic)
 {
   std::string last_subtopic = topic.substr(topic.find_last_of('/') + 1);
-  return last_subtopic != "compressed" && last_subtopic != "compressedDepth" &&
-         last_subtopic != "theora";
+  return last_subtopic != "compressed" && 
+         last_subtopic != "compressedDepth" &&
+         last_subtopic != "theora" &&
+         last_subtopic != "ffmpeg";
 }
 
 std::string getTransportFromTopic(const std::string & topic)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
@@ -39,7 +39,7 @@ namespace displays
 bool isRawTransport(const std::string & topic)
 {
   std::string last_subtopic = topic.substr(topic.find_last_of('/') + 1);
-  return last_subtopic != "compressed" && 
+  return last_subtopic != "compressed" &&
          last_subtopic != "compressedDepth" &&
          last_subtopic != "theora" &&
          last_subtopic != "ffmpeg";

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/get_transport_from_topic.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/get_transport_from_topic.cpp
@@ -40,7 +40,8 @@ bool isPointCloud2RawTransport(const std::string & topic)
 {
   std::string last_subtopic = topic.substr(topic.find_last_of('/') + 1);
   return last_subtopic != "draco" && last_subtopic != "zlib" &&
-         last_subtopic != "pcl" && last_subtopic != "zstd";
+         last_subtopic != "pcl" && last_subtopic != "zstd" &&
+         last_subtopic != "cloudini";
 }
 
 std::string getPointCloud2TransportFromTopic(const std::string & topic)


### PR DESCRIPTION
- fix topic handling in *Camera* display to support images compressed by any supported `image_transport`
- make *Image* and *Camera* display support images compressed by `ffmpeg_image_transport`
- make *PointCloud2* display support point clouds compressed by `point_cloud_transport`