### PR TITLE
Add support for ffmpeg_image_transport to Image/Camera displays and point_cloud_transport/cloudini to PointCloud2 display

### DIFF
--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -119,8 +119,9 @@
     <description>
       The Image display creates a new rendering window with an image.
     </description>
-    <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>ffmpeg_image_transport_msgs/msg/FFMPEGPacket</message_type>
     <message_type>sensor_msgs/msg/CompressedImage</message_type>
+    <message_type>sensor_msgs/msg/Image</message_type>
     <message_type>theora_image_transport/msg/Packet</message_type>
   </class>
 

--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -120,6 +120,8 @@
       The Image display creates a new rendering window with an image.
     </description>
     <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>sensor_msgs/msg/CompressedImage</message_type>
+    <message_type>theora_image_transport/msg/Packet</message_type>
   </class>
 
   <class
@@ -174,6 +176,7 @@
       The Point Cloud2 display shows data from a (recommended) sensor_msgs/PointCloud2 message.
     </description>
     <message_type>sensor_msgs/msg/PointCloud2</message_type>
+    <message_type>point_cloud_interfaces/msg/CompressedPointCloud2</message_type>
   </class>
 
   <class

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -67,6 +67,7 @@
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/load_resource.hpp"
 
+#include "rviz_default_plugins/displays/image/get_transport_from_topic.hpp"
 #include "rviz_default_plugins/displays/image/ros_image_texture.hpp"
 
 namespace rviz_default_plugins
@@ -184,7 +185,6 @@ void CameraDisplay::onInitialize()
 
   this->addChild(visibility_property_, 0);
 }
-
 
 void CameraDisplay::setupSceneNodes()
 {
@@ -346,7 +346,7 @@ void CameraDisplay::createCameraInfoSubscription()
     // TODO(anyone) Store this in a member variable
 
     std::string camera_info_topic = image_transport::getCameraInfoTopic(
-      topic_property_->getTopicStd());
+      getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
     rclcpp::SubscriptionOptions sub_opts;
     sub_opts.event_callbacks.message_lost_callback =
@@ -409,7 +409,7 @@ void CameraDisplay::clear()
   current_caminfo_.reset();
 
   std::string camera_info_topic =
-    image_transport::getCameraInfoTopic(topic_property_->getTopicStd());
+    image_transport::getCameraInfoTopic(getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
   setStatus(
     StatusLevel::Warn, CAM_INFO_STATUS,
@@ -456,7 +456,7 @@ bool CameraDisplay::updateCamera()
 
   if (!info) {
     std::string camera_info_topic = image_transport::getCameraInfoTopic(
-      topic_property_->getTopicStd());
+      getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
     setStatus(
       StatusLevel::Warn, CAM_INFO_STATUS,

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
@@ -39,8 +39,10 @@ namespace displays
 bool isRawTransport(const std::string & topic)
 {
   std::string last_subtopic = topic.substr(topic.find_last_of('/') + 1);
-  return last_subtopic != "compressed" && last_subtopic != "compressedDepth" &&
-         last_subtopic != "theora";
+  return last_subtopic != "compressed" &&
+         last_subtopic != "compressedDepth" &&
+         last_subtopic != "theora" &&
+         last_subtopic != "ffmpeg";
 }
 
 std::string getTransportFromTopic(const std::string & topic)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/get_transport_from_topic.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/get_transport_from_topic.cpp
@@ -40,7 +40,8 @@ bool isPointCloud2RawTransport(const std::string & topic)
 {
   std::string last_subtopic = topic.substr(topic.find_last_of('/') + 1);
   return last_subtopic != "draco" && last_subtopic != "zlib" &&
-         last_subtopic != "pcl" && last_subtopic != "zstd";
+         last_subtopic != "pcl" && last_subtopic != "zstd" &&
+         last_subtopic != "cloudini";
 }
 
 std::string getPointCloud2TransportFromTopic(const std::string & topic)


### PR DESCRIPTION
> [!WARNING]  
> This PR is not supposed to be merged, but only to give us a diff against `jazzy`. There is an equivalent PR against the upstream `rolling` branch at https://github.com/ros2/rviz/pull/1568.

## Description

- fix topic handling in *Camera* display to support images compressed by any supported `image_transport`
- make *Image* and *Camera* display support images compressed by `ffmpeg_image_transport`
- make *PointCloud2* display support point clouds compressed by [`cloudini`](https://github.com/facontidavide/cloudini)