### PR TITLE
Jazzy dropdown menu compressed option

### DIFF
--- a/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
@@ -62,7 +62,7 @@ public:
   void setMessageTypes(const std::vector<QString> & message_types);
   
   QString getMessageType() const
-  {return message_types_.front();}
+  {return message_types_.empty() ? QString() : message_types_.front();}
 
   std::vector<QString> getMessageTypes() const
   {return message_types_;}

--- a/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
@@ -30,6 +30,7 @@
 #define RVIZ_COMMON__PROPERTIES__ROS_TOPIC_PROPERTY_HPP_
 
 #include <string>
+#include <vector>
 
 #include "rviz_common/properties/editable_enum_property.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
@@ -58,8 +59,13 @@ public:
 
   void setMessageType(const QString & message_type);
 
+  void setMessageTypes(const std::vector<QString> & message_types);
+  
   QString getMessageType() const
-  {return message_type_;}
+  {return message_types_.front();}
+
+  std::vector<QString> getMessageTypes() const
+  {return message_types_;}
 
   QString getTopic() const
   {return getValue().toString();}
@@ -75,7 +81,7 @@ protected Q_SLOTS:
 
 private:
   ros_integration::RosNodeAbstractionIface::WeakPtr rviz_ros_node_;
-  QString message_type_;
+  std::vector<QString> message_types_;
 };
 
 class RVIZ_COMMON_PUBLIC RosFilteredTopicProperty

--- a/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
@@ -30,7 +30,6 @@
 #define RVIZ_COMMON__PROPERTIES__ROS_TOPIC_PROPERTY_HPP_
 
 #include <string>
-#include <vector>
 
 #include "rviz_common/properties/editable_enum_property.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
@@ -59,13 +58,17 @@ public:
 
   void setMessageType(const QString & message_type);
 
-  void setMessageTypes(const std::vector<QString> & message_types);
+  void setMessageTypes(const QStringList & message_types);
   
   QString getMessageType() const
-  {return message_types_.empty() ? QString() : message_types_.front();}
+  {
+    return message_types_.isEmpty() ? QString() : message_types_.first();
+  }
 
-  std::vector<QString> getMessageTypes() const
-  {return message_types_;}
+  QStringList getMessageTypes() const
+  {
+    return message_types_;
+  }
 
   QString getTopic() const
   {return getValue().toString();}
@@ -81,7 +84,7 @@ protected Q_SLOTS:
 
 private:
   ros_integration::RosNodeAbstractionIface::WeakPtr rviz_ros_node_;
-  std::vector<QString> message_types_;
+  QStringList message_types_;
 };
 
 class RVIZ_COMMON_PUBLIC RosFilteredTopicProperty

--- a/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
@@ -61,14 +61,10 @@ public:
   void setMessageTypes(const QStringList & message_types);
   
   QString getMessageType() const
-  {
-    return message_types_.isEmpty() ? QString() : message_types_.first();
-  }
+  {return message_types_.isEmpty() ? QString() : message_types_.first();}
 
   QStringList getMessageTypes() const
-  {
-    return message_types_;
-  }
+  {return message_types_;}
 
   QString getTopic() const
   {return getValue().toString();}

--- a/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
@@ -66,10 +66,10 @@ void RosTopicProperty::initialize(ros_integration::RosNodeAbstractionIface::Weak
 void RosTopicProperty::setMessageType(const QString & message_type)
 {
   message_types_.clear();
-  message_types_.push_back(message_type);
+  message_types_.append(message_type);
 }
 
-void RosTopicProperty::setMessageTypes(const std::vector<QString> & message_types)
+void RosTopicProperty::setMessageTypes(const QStringList & message_types)
 {
   message_types_ = message_types;
 }

--- a/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
@@ -51,7 +51,7 @@ RosTopicProperty::RosTopicProperty(
   QObject * receiver)
 : EditableEnumProperty(name, default_value, description, parent, changed_slot, receiver),
   rviz_ros_node_(),
-  message_type_(message_type)
+  message_types_({message_type})
 {
   connect(
     this, SIGNAL(requestOptions(EditableEnumProperty*)),
@@ -65,7 +65,13 @@ void RosTopicProperty::initialize(ros_integration::RosNodeAbstractionIface::Weak
 
 void RosTopicProperty::setMessageType(const QString & message_type)
 {
-  message_type_ = message_type;
+  message_types_.clear();
+  message_types_.push_back(message_type);
+}
+
+void RosTopicProperty::setMessageTypes(const std::vector<QString> & message_types)
+{
+  message_types_ = message_types;
 }
 
 void RosTopicProperty::fillTopicList()
@@ -73,15 +79,17 @@ void RosTopicProperty::fillTopicList()
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
   clearOptions();
 
-  std::string std_message_type = message_type_.toStdString();
   std::map<std::string, std::vector<std::string>> published_topics =
     rviz_ros_node_.lock()->get_topic_names_and_types();
 
   for (const auto & topic : published_topics) {
-    // Only add topics whose type matches.
     for (const auto & type : topic.second) {
-      if (type == std_message_type || (type == "sensor_msgs/msg/CompressedImage" && std_message_type == "sensor_msgs/msg/Image")) {
-        addOptionStd(topic.first);
+      for (const auto & message_type : message_types_) {
+        std::string std_message_type = message_type.toStdString();
+        if (type == std_message_type) {
+          addOptionStd(topic.first);
+          break;
+        }
       }
     }
   }

--- a/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
@@ -80,7 +80,7 @@ void RosTopicProperty::fillTopicList()
   for (const auto & topic : published_topics) {
     // Only add topics whose type matches.
     for (const auto & type : topic.second) {
-      if (type == std_message_type) {
+      if (type == std_message_type || (type == "sensor_msgs/msg/CompressedImage" && std_message_type == "sensor_msgs/msg/Image")) {
         addOptionStd(topic.first);
       }
     }

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -61,7 +61,7 @@ public:
   {
     QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
     std::vector<QString> supported_types = {
-      "sensor_msgs/msg/Image",
+      message_type,
       "sensor_msgs/msg/CompressedImage",
       "ffmpeg_image_transport/msg/FFMPEGPacket",
       "theora_image_transport/msg/Packet"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -60,7 +60,14 @@ public:
   : messages_received_(0)
   {
     QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
-    topic_property_->setMessageType(message_type);
+    std::vector<QString> supported_types = {
+      "sensor_msgs/msg/Image",
+      "sensor_msgs/msg/CompressedImage",
+      "ffmpeg_image_transport/msg/FFMPEGPacket",
+      "theora_image_transport/msg/Packet"
+    };
+
+    topic_property_->setMessageTypes(supported_types);
     topic_property_->setDescription(message_type + " topic to subscribe to.");
   }
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -60,7 +60,7 @@ public:
   : messages_received_(0)
   {
     QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
-    std::vector<QString> supported_types = {
+    QStringList supported_types = {
       message_type,
       "sensor_msgs/msg/CompressedImage",
       "ffmpeg_image_transport/msg/FFMPEGPacket",

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -60,7 +60,7 @@ public:
     QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
     std::vector<QString> supported_types = {
       "sensor_msgs/msg/PointCloud2",
-      "point_cloud_intefaces/msg/CompressedPointCloud2"
+      "point_cloud_interfaces/msg/CompressedPointCloud2"
     };
       
     topic_property_->setMessageTypes(supported_types);

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -58,7 +58,7 @@ public:
   : messages_received_(0)
   {
     QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
-    std::vector<QString> supported_types = {
+    QStringList supported_types = {
       message_type,
       "point_cloud_interfaces/msg/CompressedPointCloud2"
     };

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -59,7 +59,7 @@ public:
   {
     QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
     std::vector<QString> supported_types = {
-      "sensor_msgs/msg/PointCloud2",
+      message_type,
       "point_cloud_interfaces/msg/CompressedPointCloud2"
     };
       

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -58,7 +58,12 @@ public:
   : messages_received_(0)
   {
     QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
-    topic_property_->setMessageType(message_type);
+    std::vector<QString> supported_types = {
+      "sensor_msgs/msg/PointCloud2",
+      "point_cloud_intefaces/msg/CompressedPointCloud2"
+    };
+      
+    topic_property_->setMessageTypes(supported_types);
     topic_property_->setDescription(message_type + " topic to subscribe to.");
   }
 

--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -120,6 +120,7 @@
       The Image display creates a new rendering window with an image.
     </description>
     <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>sensor_msgs/msg/CompressedImage</message_type>
   </class>
 
   <class

--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -119,8 +119,10 @@
     <description>
       The Image display creates a new rendering window with an image.
     </description>
-    <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>ffmpeg_image_transport_msgs/msg/FFMPEGPacket</message_type>
     <message_type>sensor_msgs/msg/CompressedImage</message_type>
+    <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>theora_image_transport/msg/Packet</message_type>
   </class>
 
   <class

--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -31,8 +31,10 @@
     <description>
       Displays an image from a camera, with the visualized world rendered behind it.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Camera"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>ffmpeg_image_transport_msgs/msg/FFMPEGPacket</message_type>
     <message_type>sensor_msgs/msg/CompressedImage</message_type>
+    <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>theora_image_transport/msg/Packet</message_type>
   </class>
 
   <class

--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -178,6 +178,7 @@
     <description>
       The Point Cloud2 display shows data from a (recommended) sensor_msgs/PointCloud2 message.
     </description>
+    <message_type>point_cloud_interfaces/msg/CompressedPointCloud2</message_type>
     <message_type>sensor_msgs/msg/PointCloud2</message_type>
   </class>
 


### PR DESCRIPTION
This MR updates the behavior of the **Image** and **PointCloud2** display dropdown in RViz2. Previously, the dropdown only listed topics of type `sensor_msgs/msg/Image`, so `CompressedImage` topics (e.g., `/camera/image/compressed`) were not visible, even though RViz2 could already visualize them. Same for `sensor_msgs/msg/PointCloud2` and `point_cloud_interfaces/msg/CompressedPointCloud2`.

With this change, **Compressed image and pointcloud2** topics are now included in the dropdown menu, making it easier for users to select these topics without manually typing the topic name. 

Additionally, **Compressed image and pointcloud2** topics are also shown in the *By topic* section thanks to the change in `plugins_description.xml`.

Image Display added **by display type**:
<img width="1920" height="1151" alt="image" src="https://github.com/user-attachments/assets/d78b8b6e-7f1f-4876-9de8-7988fad37c6d" />


Image Display added **by topic** (same results):
<img width="1920" height="1120" alt="image" src="https://github.com/user-attachments/assets/47eef2e7-7796-47a3-931b-51b9e3fc17bf" />


PointCloud2 Display added **by display type**:
<img width="1920" height="1201" alt="image" src="https://github.com/user-attachments/assets/f8fcae4c-2766-433a-84a2-695a387c2f64" />


PointCloud2 Display added **by topic** (same results):
<img width="1920" height="1221" alt="image" src="https://github.com/user-attachments/assets/da15a184-da68-4e27-9060-0a20fa63b236" />

